### PR TITLE
Clear on close find and replace panel

### DIFF
--- a/lib/minimap-find-and-replace.coffee
+++ b/lib/minimap-find-and-replace.coffee
@@ -31,15 +31,17 @@ module.exports =
     else
       @initializeLegacyAPI()
 
-    @subscriptions.add atom.commands.add 'atom-workspace',
-      'find-and-replace:show': => @discoverMarkers()
-      'find-and-replace:toggle': => @discoverMarkers()
-      'find-and-replace:show-replace': => @discoverMarkers()
-      'core:cancel': => @clearBindings()
-      'core:close': => @clearBindings()
-
   initializeServiceAPI: ->
     atom.packages.serviceHub.consume 'find-and-replace', '0.0.1', (fnr) =>
+      [fnrPanel] = atom.workspace.getBottomPanels().filter (panel) ->
+        return panel.element.firstChild.classList.contains "find-and-replace"
+
+      fnrPanel.onDidChangeVisible (visible) =>
+        if visible
+          @discoverMarkers()
+        else
+          @clearBindings()
+
       @subscriptions.add @minimap.observeMinimaps (minimap) =>
         MinimapFindAndReplaceBinding ?= require './minimap-find-and-replace-binding'
 

--- a/spec/minimap-find-and-replace-spec.coffee
+++ b/spec/minimap-find-and-replace-spec.coffee
@@ -1,33 +1,58 @@
 MinimapFindAndReplace = require '../lib/minimap-find-and-replace'
-{WorkspaceView} = require 'atom'
 
-describe "MinimapFindAndReplace", ->
+describe 'MinimapFindAndReplace', ->
+  [workspace] = []
+
   beforeEach ->
-    runs ->
-      atom.workspaceView = new WorkspaceView
-      atom.workspaceView.openSync('sample.js')
-
-    runs ->
-      atom.workspaceView.attachToDom()
-      editorView = atom.workspaceView.getActiveView()
-      editorView.setText("This is the file content")
+    workspace = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspace)
 
     waitsForPromise ->
-      promise = atom.packages.activatePackage('minimap')
-      atom.workspaceView.trigger 'minimap:toggle'
-      promise
+      atom.packages.activatePackage('minimap')
 
     waitsForPromise ->
       promise = atom.packages.activatePackage('find-and-replace')
-      atom.workspaceView.trigger 'find-and-replace:show'
+      atom.commands.dispatch(workspace, 'find-and-replace:show')
       promise
 
-  describe "when the toggle event is triggered", ->
+  describe 'when the package is activated', ->
     beforeEach ->
-      waitsForPromise ->
-        promise = atom.packages.activatePackage('minimap-find-and-replace')
-        atom.workspaceView.trigger 'minimap-find-and-replace:toggle'
-        promise
+      waitsForPromise -> atom.packages.activatePackage('minimap-find-and-replace')
 
-    it 'should exist', ->
-      expect()
+    it 'should activate', ->
+      expect(MinimapFindAndReplace.isActive()).toBe(true)
+
+    describe 'when find-and-replace is closed', ->
+      beforeEach ->
+        atom.commands.dispatch(workspace, 'find-and-replace:show')
+        spyOn(MinimapFindAndReplace, "clearBindings")
+
+      it "should clear on core:cancel", ->
+        atom.commands.dispatch(workspace, "core:cancel")
+        expect(MinimapFindAndReplace.clearBindings.calls.length).toBe(1)
+
+      it "should clear on find-and-replace:toggle", ->
+        atom.commands.dispatch(workspace, "find-and-replace:toggle")
+        atom.commands.dispatch(workspace, "find-and-replace:toggle")
+        expect(MinimapFindAndReplace.clearBindings.calls.length).toBe(1)
+
+      it "should clear on close button pressed", ->
+        document.querySelector(".find-and-replace .close-button").click()
+        expect(MinimapFindAndReplace.clearBindings.calls.length).toBe(1)
+
+    describe 'when find-and-replace is opened', ->
+      beforeEach ->
+        atom.commands.dispatch(workspace, 'core:cancel')
+        spyOn(MinimapFindAndReplace, "discoverMarkers")
+
+      it "should display markers on find-and-replace:show", ->
+        atom.commands.dispatch(workspace, "find-and-replace:show")
+        expect(MinimapFindAndReplace.discoverMarkers.calls.length).toBe(1)
+
+      it "should display markers on find-and-replace:show-replace", ->
+        atom.commands.dispatch(workspace, "find-and-replace:show-replace")
+        expect(MinimapFindAndReplace.discoverMarkers.calls.length).toBe(1)
+
+      it "should display markers on find-and-replace:toggle", ->
+        atom.commands.dispatch(workspace, "find-and-replace:toggle")
+        expect(MinimapFindAndReplace.discoverMarkers.calls.length).toBe(1)


### PR DESCRIPTION
Right now the markers don't clear if the panel is closed with `find-and-replace:toggle` or by clicking the close button

The PR changes the way the markers are displayed or cleared by using the [`panel.onDidChangeVisible()`](https://atom.io/docs/api/latest/Panel#instance-onDidChangeVisible) instead of registering commands

I also got the tests working and added some tests